### PR TITLE
Rename `Response` to `AtomResponse` to avoid aliasing and move it one level up

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ use Spaze\Exports\Atom\Constructs\Person;
 use Spaze\Exports\Atom\Constructs\Text;
 use Spaze\Exports\Atom\Elements\Entry;
 use Spaze\Exports\Atom\Feed;
-use Spaze\Exports\Bridges\Nette\Atom\Response;
+use Spaze\Exports\Bridges\Nette\AtomResponse;
 
 // [ ... ]
 
@@ -39,7 +39,7 @@ use Spaze\Exports\Bridges\Nette\Atom\Response;
         $entry->setContent(new Text('other <strong>content-2</strong>'));
         $feed->addEntry($entry);
 
-        $this->sendResponse(new Response($feed));
+        $this->sendResponse(new AtomResponse($feed));
     }
 
 // [ ... ]

--- a/src/Bridges/Nette/AtomResponse.php
+++ b/src/Bridges/Nette/AtomResponse.php
@@ -3,7 +3,7 @@ declare(strict_types = 1);
 
 namespace Spaze\Exports\Bridges\Nette\Atom;
 
-use Nette\Application\Response as NetteResponse;
+use Nette\Application\Response;
 use Nette\Http\IRequest;
 use Nette\Http\IResponse;
 use Spaze\Exports\Atom\Feed;
@@ -14,7 +14,7 @@ use Spaze\Exports\Bridges\Nette\AtomResponseContentType;
  *
  * @author Michal Špaček
  */
-class Response implements NetteResponse
+class AtomResponse implements Response
 {
 
 	public function __construct(


### PR DESCRIPTION
Follow-ups:
- #25