### PR TITLE
Correct namespace after `AtomResponse` has been moved one level up

### DIFF
--- a/src/Bridges/Nette/AtomResponse.php
+++ b/src/Bridges/Nette/AtomResponse.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types = 1);
 
-namespace Spaze\Exports\Bridges\Nette\Atom;
+namespace Spaze\Exports\Bridges\Nette;
 
 use Nette\Application\Response;
 use Nette\Http\IRequest;


### PR DESCRIPTION
Follow-up to #16